### PR TITLE
Generate pointers for slices if needed

### DIFF
--- a/generator.go
+++ b/generator.go
@@ -605,6 +605,9 @@ func processType(s *metaSchema, pName, pDesc, path, parentPath string) (typeRef 
 					return ""
 				}
 				sf.TypePrefix = "[]"
+				if !sf.Required && *ptrForOmit {
+					sf.Nullable = true
+				}
 				sf.TypeRef = gotType
 			default:
 				sf.TypePrefix = typeEmptyInterfaceSlice


### PR DESCRIPTION
Given a JSON schema along the lines of this: 
```json
{
  ...
  "properties": {
    "code": {
      "type": "string"
    },
    "attributes": {
      "type": "array"
      ...
    }
  },
  "required": ["code"]
}
```

Schematyper will now generate this struct if the `ptr-for-omit` flag is provided to the `go:generate` command:
```golang
type Input struct {
  Code string 
  Attributes *[]InputAttributes
}
```

instead of:
```golang
type Input struct {
  Code string 
  Attributes []InputAttributes
}
```